### PR TITLE
Changed error message to avoid confusion

### DIFF
--- a/dll/dllmain.cpp
+++ b/dll/dllmain.cpp
@@ -101,7 +101,7 @@ DWORD WINAPI doPatching(LPVOID lpParam)
 
     if (!success)
     {
-        MessageBoxA(0, "Stutter fix failed. You may be running an unsupported version.", "", 0);
+        MessageBoxA(0, "FromStutterFix failed. You may be running an unsupported version.", "", 0);
         return 1;
     }
 


### PR DESCRIPTION
Lots of people on a [different stutter fix mod](https://www.nexusmods.com/eldenring/mods/2859) were finding themselves confused when they thought the error message from this mod was from that mod, so the error message should be less ambiguous.

BTW, I've tested the new version with both Elden Ring and Sekiro, which are the two games I have, and they both worked :) I think it's safe to say it's working.